### PR TITLE
Preserve and remap PDF outline (bookmarks) when filtering pages

### DIFF
--- a/pagewielder/cli.py
+++ b/pagewielder/cli.py
@@ -136,11 +136,26 @@ def filter_command(args: Namespace) -> int:
         for page_dimensions in maybe_selected_dimensions:
             selected_pages.update(dimensions_to_pages[page_dimensions])
 
-        with pikepdf.Pdf.new() as output_pdf:
-            for i, page in enumerate(input_pdf.pages, start=1):
-                if i not in selected_pages:
-                    output_pdf.pages.append(page)
-            output_pdf.save(output_path)
+        input_page_objgens = {
+            page.obj.objgen: i for i, page in enumerate(input_pdf.pages)
+        }
+        old_to_new: dict[int, int] = {}
+        new_idx = 0
+        for old_idx in range(len(input_pdf.pages)):
+            if (old_idx + 1) not in selected_pages:
+                old_to_new[old_idx] = new_idx
+                new_idx += 1
+
+        with input_pdf.open_outline() as input_outline:
+            with pikepdf.Pdf.new() as output_pdf:
+                for i, page in enumerate(input_pdf.pages, start=1):
+                    if i not in selected_pages:
+                        output_pdf.pages.append(page)
+                with output_pdf.open_outline() as output_outline:
+                    output_outline.root[:] = core.remap_outline(
+                        input_outline.root, input_page_objgens, old_to_new
+                    )
+                output_pdf.save(output_path)
 
     print(f"Filtered PDF saved as {output_path}")
 

--- a/pagewielder/cli.py
+++ b/pagewielder/cli.py
@@ -132,19 +132,9 @@ def filter_command(args: Namespace) -> int:
             print("No page sets selected. No output file created.", file=sys.stderr)
             return 1
 
-        selected_pages: Pages = set()
-        for page_dimensions in maybe_selected_dimensions:
-            selected_pages.update(dimensions_to_pages[page_dimensions])
+        selected_pages: Pages = {p for d in maybe_selected_dimensions for p in dimensions_to_pages[d]}
 
-        input_page_objgens = {
-            page.obj.objgen: i for i, page in enumerate(input_pdf.pages)
-        }
-        old_to_new: dict[int, int] = {}
-        new_idx = 0
-        for old_idx in range(len(input_pdf.pages)):
-            if (old_idx + 1) not in selected_pages:
-                old_to_new[old_idx] = new_idx
-                new_idx += 1
+        input_page_objgens, old_to_new = core.build_page_remap(input_pdf, selected_pages)
 
         with input_pdf.open_outline() as input_outline:
             with pikepdf.Pdf.new() as output_pdf:

--- a/pagewielder/core.py
+++ b/pagewielder/core.py
@@ -21,6 +21,33 @@ def _get_dimensions(page: Page) -> Dimensions:
     return (rect.width, rect.height)
 
 
+def build_page_remap(
+    pdf: Pdf,
+    removed_pages: Pages,
+) -> tuple[dict[tuple[int, int], int], dict[int, int]]:
+    """Build page remapping data needed to preserve the outline after page removal.
+
+    Args:
+        pdf: Input PDF with original pages.
+        removed_pages: 1-based set of page numbers that will be removed.
+
+    Returns:
+        A tuple of (input_page_objgens, old_to_new) where input_page_objgens
+        maps each page's (obj, gen) pair to its 0-based index in the input PDF,
+        and old_to_new maps each kept page's 0-based old index to its 0-based
+        new index in the output PDF.
+    """
+    input_page_objgens: dict[tuple[int, int], int] = {}
+    old_to_new: dict[int, int] = {}
+    new_idx = 0
+    for old_idx, page in enumerate(pdf.pages):
+        input_page_objgens[page.obj.objgen] = old_idx
+        if (old_idx + 1) not in removed_pages:
+            old_to_new[old_idx] = new_idx
+            new_idx += 1
+    return input_page_objgens, old_to_new
+
+
 def remap_outline(
     items: list[OutlineItem],
     input_page_objgens: dict[tuple[int, int], int],
@@ -56,7 +83,7 @@ def remap_outline(
                     item.title,
                     old_to_new[old_idx],
                     page_location=item.page_location,
-                    page_location_args=item.page_location_args,
+                    **item.page_location_kwargs,
                 )
                 new_item.children = new_children
                 result.append(new_item)

--- a/pagewielder/core.py
+++ b/pagewielder/core.py
@@ -2,7 +2,7 @@
 
 import collections
 
-from pikepdf import Page, Pdf, Rectangle
+from pikepdf import OutlineItem, Page, Pdf, Rectangle
 
 Dimensions = tuple[float, float]
 Pages = set[int]
@@ -19,6 +19,56 @@ def _get_dimensions(page: Page) -> Dimensions:
     """
     rect = Rectangle(page.mediabox)
     return (rect.width, rect.height)
+
+
+def remap_outline(
+    items: list[OutlineItem],
+    input_page_objgens: dict[tuple[int, int], int],
+    old_to_new: dict[int, int],
+) -> list[OutlineItem]:
+    """Recursively filter and remap outline items after page removal.
+
+    Items whose destination page was removed are dropped; their children are
+    promoted to the parent level. Items whose destination page was kept have
+    their destinations updated to the new 0-based page index.
+
+    Args:
+        items: Outline items to process.
+        input_page_objgens: Mapping from (obj, gen) tuple of each input page to
+            its 0-based index in the input PDF.
+        old_to_new: Mapping from 0-based old page index to 0-based new index
+            for pages that were kept.
+
+    Returns:
+        Filtered and remapped list of outline items.
+    """
+    result = []
+    for item in items:
+        new_children = remap_outline(item.children, input_page_objgens, old_to_new)
+        dest = item.destination
+        if isinstance(dest, list) and dest:
+            try:
+                old_idx = input_page_objgens.get(dest[0].objgen)
+                if old_idx is None or old_idx not in old_to_new:
+                    result.extend(new_children)
+                    continue
+                new_item = OutlineItem(
+                    item.title,
+                    old_to_new[old_idx],
+                    page_location=item.page_location,
+                    page_location_args=item.page_location_args,
+                )
+                new_item.children = new_children
+                result.append(new_item)
+            except (AttributeError, KeyError):
+                new_item = OutlineItem(item.title, dest)
+                new_item.children = new_children
+                result.append(new_item)
+        else:
+            new_item = OutlineItem(item.title, dest)
+            new_item.children = new_children
+            result.append(new_item)
+    return result
 
 
 def map_dimensions_to_pages(pdf: Pdf) -> dict[Dimensions, Pages]:


### PR DESCRIPTION
## Summary
This PR adds support for preserving and remapping PDF outlines (bookmarks) when filtering pages from a PDF. Previously, the filter command would discard all outline information. Now it intelligently handles bookmarks by removing entries for deleted pages and updating page references for retained pages.

## Key Changes
- **New `remap_outline()` function in `core.py`**: Recursively processes outline items to:
  - Remove outline entries whose destination pages were deleted
  - Promote orphaned children to the parent level when their parent is removed
  - Update page references to reflect the new 0-based page indices after filtering
  
- **Updated `filter_command()` in `cli.py`**: 
  - Build a mapping of input page object references to their original indices
  - Create a mapping from old to new page indices for retained pages
  - Extract the input PDF's outline and remap it using the new function
  - Write the remapped outline to the output PDF

## Implementation Details
- The `remap_outline()` function handles edge cases where outline destinations may not be standard page references (e.g., external links or malformed destinations)
- Outline items are processed recursively to maintain the hierarchical structure while filtering
- The remapping preserves all outline properties (title, page location, location arguments) while updating only the page indices

https://claude.ai/code/session_01JvPUHacrELuygxXCQeq6KP