### PR TITLE
Preserve document features when filtering pages

### DIFF
--- a/pagewielder/cli.py
+++ b/pagewielder/cli.py
@@ -136,11 +136,9 @@ def filter_command(args: Namespace) -> int:
         for page_dimensions in maybe_selected_dimensions:
             selected_pages.update(dimensions_to_pages[page_dimensions])
 
-        with pikepdf.Pdf.new() as output_pdf:
-            for i, page in enumerate(input_pdf.pages, start=1):
-                if i not in selected_pages:
-                    output_pdf.pages.append(page)
-            output_pdf.save(output_path)
+        # Remove pages in place so document-level features like the outline survive.
+        core.remove_pages(input_pdf, selected_pages)
+        input_pdf.save(output_path)
 
     print(f"Filtered PDF saved as {output_path}")
 

--- a/pagewielder/cli.py
+++ b/pagewielder/cli.py
@@ -176,11 +176,10 @@ def excerpt_command(args: Namespace) -> int:
             print(f"Error: {e}", file=sys.stderr)
             return 1
 
-        with pikepdf.Pdf.new() as output_pdf:
-            # pikepdf uses 0-based indexing internally
-            for i in range(start_page - 1, end_page):
-                output_pdf.pages.append(input_pdf.pages[i])
-            output_pdf.save(output_path)
+        # Remove pages in place so document-level features like the outline survive.
+        unselected_pages = set(range(1, total_pages + 1)) - set(range(start_page, end_page + 1))
+        core.remove_pages(input_pdf, unselected_pages)
+        input_pdf.save(output_path)
 
     page_count = end_page - start_page + 1
     print(f"Extracted {page_count} page{'s' if page_count != 1 else ''} ({start_page}:{end_page}) to {output_path}")

--- a/pagewielder/core.py
+++ b/pagewielder/core.py
@@ -1,11 +1,13 @@
 """Core functionality for pagewielder."""
 
 import collections
+from typing import Optional
 
-from pikepdf import Page, Pdf, Rectangle
+from pikepdf import Array, Dictionary, Name, NameTree, Object, OutlineItem, Page, Pdf, Rectangle, String
 
 Dimensions = tuple[float, float]
 Pages = set[int]
+_ObjGen = tuple[int, int]
 
 
 def _get_dimensions(page: Page) -> Dimensions:
@@ -38,3 +40,89 @@ def map_dimensions_to_pages(pdf: Pdf) -> dict[Dimensions, Pages]:
         ret[dimensions].add(i + 1)
 
     return ret
+
+
+def _resolve_named_destination(pdf: Pdf, name: Object) -> Optional[Object]:
+    """Resolve a named destination to the destination it refers to.
+
+    Args:
+        pdf: The PDF file the destination belongs to.
+        name: A ``Name`` (PDF 1.1 style) or ``String`` destination reference.
+
+    Returns:
+        The destination the name resolves to, or None if it cannot be found.
+    """
+    if isinstance(name, Name):
+        dests = pdf.Root.get(Name.Dests)
+        return dests.get(name) if isinstance(dests, Dictionary) else None
+    names = pdf.Root.get(Name.Names)
+    if isinstance(names, Dictionary) and Name.Dests in names:
+        return NameTree(names.Dests).get(str(name))
+    return None
+
+
+def _destination_page(pdf: Pdf, item: OutlineItem) -> Optional[Object]:
+    """Find the page object an outline item points at, if it can be determined.
+
+    Args:
+        pdf: The PDF file the outline item belongs to.
+        item: An outline item.
+
+    Returns:
+        The page object the item targets, or None if it cannot be determined.
+    """
+    dest: Optional[Object | int] = item.destination
+    if dest is None and isinstance(item.action, Dictionary) and item.action.get(Name.S) == Name.GoTo:
+        dest = item.action.get(Name.D)
+    if isinstance(dest, (Name, String)):
+        dest = _resolve_named_destination(pdf, dest)
+    if isinstance(dest, Dictionary):
+        dest = dest.get(Name.D)
+    if isinstance(dest, Array) and len(dest) > 0:
+        target = dest[0]
+        if isinstance(target, Dictionary):
+            return target
+    return None
+
+
+def _prune_outline_items(pdf: Pdf, items: list[OutlineItem], removed: set[_ObjGen]) -> list[OutlineItem]:
+    """Drop outline items that point at removed pages, promoting their children.
+
+    Args:
+        pdf: The PDF file the outline belongs to.
+        items: Outline items at one level of the outline tree.
+        removed: Object identifiers of the removed page objects.
+
+    Returns:
+        The outline items to keep.
+    """
+    kept: list[OutlineItem] = []
+    for item in items:
+        item.children = _prune_outline_items(pdf, item.children, removed)
+        page = _destination_page(pdf, item)
+        if page is not None and page.objgen in removed:
+            kept.extend(item.children)
+        else:
+            kept.append(item)
+    return kept
+
+
+def remove_pages(pdf: Pdf, pages: Pages) -> None:
+    """Remove the given pages from a PDF in place.
+
+    Document-level features such as the outline (table of contents) are kept
+    intact for the remaining pages.  Outline entries that point at a removed
+    page are dropped and replaced by their children, if any.
+
+    Args:
+        pdf: A PDF file.
+        pages: The set of pages to remove, numbered starting from 1.
+    """
+    removed: set[_ObjGen] = {pdf.pages[number - 1].obj.objgen for number in pages}
+
+    for number in sorted(pages, reverse=True):
+        del pdf.pages[number - 1]
+
+    if Name.Outlines in pdf.Root:
+        with pdf.open_outline() as outline:
+            outline.root[:] = _prune_outline_items(pdf, outline.root, removed)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,64 @@
+"""Tests for pagewielder.cli."""
+
+import tempfile
+import unittest
+from argparse import Namespace
+from pathlib import Path
+
+import pikepdf
+from pikepdf import OutlineItem, Pdf
+
+from pagewielder import cli
+
+A4 = (595.0, 842.0)
+
+
+def _make_input_pdf(path: Path) -> None:
+    with Pdf.new() as pdf:
+        for _ in range(4):
+            pdf.add_blank_page(page_size=A4)
+        with pdf.open_outline() as outline:
+            outline.root.append(OutlineItem("Chapter 1", 0))
+            outline.root.append(OutlineItem("Chapter 2", 1))
+            outline.root.append(OutlineItem("Chapter 3", 3))
+        pdf.save(path)
+
+
+class ExcerptCommandTest(unittest.TestCase):
+    """Tests for excerpt_command."""
+
+    def test_preserves_outline_for_extracted_pages(self) -> None:
+        """The outline survives extraction, pruned to the extracted pages."""
+        with tempfile.TemporaryDirectory() as tmp:
+            input_path = Path(tmp) / "input.pdf"
+            output_path = Path(tmp) / "output.pdf"
+            _make_input_pdf(input_path)
+
+            args = Namespace(input=input_path, pages="2:3", output=output_path)
+            self.assertEqual(0, cli.excerpt_command(args))
+
+            with pikepdf.open(output_path) as pdf:
+                self.assertEqual(2, len(pdf.pages))
+                with pdf.open_outline() as outline:
+                    self.assertEqual(["Chapter 2"], [item.title for item in outline.root])
+
+
+class ParsePageRangeTest(unittest.TestCase):
+    """Tests for parse_page_range."""
+
+    def test_parses_ranges(self) -> None:
+        """Single pages, ranges, and open-ended ranges are parsed."""
+        self.assertEqual((7, 7), cli.parse_page_range("7", 10))
+        self.assertEqual((1, 5), cli.parse_page_range("1:5", 10))
+        self.assertEqual((3, 10), cli.parse_page_range("3:", 10))
+        self.assertEqual((1, 10), cli.parse_page_range(":10", 10))
+
+    def test_rejects_invalid_ranges(self) -> None:
+        """Out-of-range and malformed inputs raise ValueError."""
+        for page_range in ("0", "11", "5:1", "1:11", "abc"):
+            with self.assertRaises(ValueError):
+                cli.parse_page_range(page_range, 10)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,126 @@
+"""Tests for pagewielder.core."""
+
+import io
+import unittest
+
+import pikepdf
+from pikepdf import Array, Dictionary, Name, NameTree, OutlineItem, Pdf, String
+
+from pagewielder import core
+
+A4 = (595.0, 842.0)
+PLATE = (1000.0, 700.0)
+
+
+def _make_pdf(sizes: list[tuple[float, float]]) -> Pdf:
+    pdf = Pdf.new()
+    for size in sizes:
+        pdf.add_blank_page(page_size=size)
+    return pdf
+
+
+def _outline_titles(pdf: Pdf) -> list[str]:
+    with pdf.open_outline() as outline:
+        return [item.title for item in outline.root]
+
+
+class MapDimensionsToPagesTest(unittest.TestCase):
+    """Tests for map_dimensions_to_pages."""
+
+    def test_groups_pages_by_dimensions(self) -> None:
+        """Pages are grouped by their dimensions."""
+        with _make_pdf([A4, A4, PLATE, A4]) as pdf:
+            mapping = core.map_dimensions_to_pages(pdf)
+        self.assertEqual({A4: {1, 2, 4}, PLATE: {3}}, mapping)
+
+
+class RemovePagesTest(unittest.TestCase):
+    """Tests for remove_pages."""
+
+    def test_removes_pages(self) -> None:
+        """The given pages are removed."""
+        with _make_pdf([A4, A4, PLATE, A4]) as pdf:
+            core.remove_pages(pdf, {3})
+            self.assertEqual(3, len(pdf.pages))
+            self.assertEqual({A4: {1, 2, 3}}, core.map_dimensions_to_pages(pdf))
+
+    def test_works_without_outline(self) -> None:
+        """PDFs without an outline are handled."""
+        with _make_pdf([A4, PLATE]) as pdf:
+            core.remove_pages(pdf, {2})
+            self.assertEqual(1, len(pdf.pages))
+            self.assertNotIn(Name.Outlines, pdf.Root)
+
+    def test_preserves_outline_for_remaining_pages(self) -> None:
+        """Outline entries for remaining pages survive."""
+        with _make_pdf([A4, A4, PLATE, A4]) as pdf:
+            with pdf.open_outline() as outline:
+                outline.root.append(OutlineItem("Chapter 1", 0))
+                outline.root.append(OutlineItem("Chapter 2", 1))
+                outline.root.append(OutlineItem("Chapter 3", 3))
+
+            core.remove_pages(pdf, {3})
+
+            self.assertEqual(["Chapter 1", "Chapter 2", "Chapter 3"], _outline_titles(pdf))
+            with pdf.open_outline() as outline:
+                last = outline.root[-1].destination
+                assert isinstance(last, Array)
+                self.assertEqual(pdf.pages[2].obj.objgen, last[0].objgen)
+
+    def test_prunes_entries_for_removed_pages_and_promotes_children(self) -> None:
+        """Entries for removed pages are dropped and their children promoted."""
+        with _make_pdf([A4, A4, PLATE, A4]) as pdf:
+            with pdf.open_outline() as outline:
+                plate = OutlineItem("Plate", 2)
+                plate.children.append(OutlineItem("Detail", 3))
+                outline.root.append(OutlineItem("Chapter 1", 0))
+                outline.root.append(plate)
+
+            core.remove_pages(pdf, {3})
+
+            self.assertEqual(["Chapter 1", "Detail"], _outline_titles(pdf))
+
+    def test_prunes_entries_using_goto_actions(self) -> None:
+        """Entries using GoTo actions are pruned."""
+        with _make_pdf([A4, PLATE]) as pdf:
+            with pdf.open_outline() as outline:
+                action = Dictionary(S=Name.GoTo, D=Array([pdf.pages[1].obj, Name.Fit]))
+                outline.root.append(OutlineItem("Chapter 1", 0))
+                outline.root.append(OutlineItem("Plate", action=action))
+
+            core.remove_pages(pdf, {2})
+
+            self.assertEqual(["Chapter 1"], _outline_titles(pdf))
+
+    def test_prunes_entries_using_named_destinations(self) -> None:
+        """Entries using named destinations are pruned."""
+        with _make_pdf([A4, PLATE]) as pdf:
+            name_tree = NameTree.new(pdf)
+            name_tree["plate"] = Array([pdf.pages[1].obj, Name.Fit])
+            pdf.Root.Names = pdf.make_indirect(Dictionary(Dests=name_tree.obj))
+            with pdf.open_outline() as outline:
+                outline.root.append(OutlineItem("Chapter 1", 0))
+                outline.root.append(OutlineItem("Plate", String("plate")))
+
+            core.remove_pages(pdf, {2})
+
+            self.assertEqual(["Chapter 1"], _outline_titles(pdf))
+
+    def test_outline_survives_save_and_reload(self) -> None:
+        """The pruned outline survives a save/reload round trip."""
+        buffer = io.BytesIO()
+        with _make_pdf([A4, A4, PLATE]) as pdf:
+            with pdf.open_outline() as outline:
+                outline.root.append(OutlineItem("Chapter 1", 0))
+                outline.root.append(OutlineItem("Chapter 2", 1))
+            core.remove_pages(pdf, {3})
+            pdf.save(buffer)
+
+        buffer.seek(0)
+        with pikepdf.open(buffer) as reloaded:
+            self.assertEqual(2, len(reloaded.pages))
+            self.assertEqual(["Chapter 1", "Chapter 2"], _outline_titles(reloaded))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
This PR adds functionality to remove pages from PDFs while preserving document-level features like outlines (table of contents). Previously, the filter command would create a new PDF with only selected pages, losing all outline entries. Now it removes unwanted pages in place, maintaining the outline structure for remaining pages.

## Key Changes
- **New `remove_pages()` function** in `core.py`: Removes specified pages from a PDF while intelligently handling outline entries
  - Drops outline entries pointing to removed pages
  - Promotes children of removed entries to maintain document structure
  - Handles multiple destination formats: direct page references, GoTo actions, and named destinations
  
- **Outline pruning logic**: Implements `_prune_outline_items()`, `_destination_page()`, and `_resolve_named_destination()` helper functions to:
  - Traverse the outline tree recursively
  - Resolve various destination reference types (Name, String, Dictionary, Array)
  - Track removed pages by object identifier to accurately match outline targets
  
- **Updated `filter_command()`**: Changed from creating a new PDF with selected pages to using `remove_pages()` to filter in place, preserving document structure

- **Comprehensive test suite** in `tests/test_core.py`: 126 lines of tests covering:
  - Basic page removal and dimension mapping
  - Outline preservation for remaining pages
  - Outline entry pruning and child promotion
  - GoTo action and named destination handling
  - Save/reload round-trip integrity

## Notable Implementation Details
- Uses `objgen` (object generation number) tuples to reliably identify removed pages across different destination reference formats
- Handles PDFs without outlines gracefully
- Maintains outline structure integrity through recursive child promotion when parent entries are removed

https://claude.ai/code/session_018MMP62LSZWadQ96CaEJgc1